### PR TITLE
Adds hidden files toggle button using pop up menu and switch

### DIFF
--- a/lib/widgets/workspace.dart
+++ b/lib/widgets/workspace.dart
@@ -95,6 +95,33 @@ class _FilesWorkspaceState extends State<FilesWorkspace> {
               ),
             ],
             actions: [
+              PopupMenuButton<String>(
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(8)),
+                ),
+                offset: const Offset(0, 50),
+                onSelected: (value) {
+                  if (value == 'showHidden') {
+                    controller.showHidden = !controller.showHidden;
+                  }
+                },
+                itemBuilder: (context) => [
+                  PopupMenuItem(
+                    value: 'showHidden',
+                    child: SwitchListTile(
+                      title: const Text('Show hidden files'),
+                      value: controller.showHidden,
+                      onChanged: (value) {
+                        setState(() {
+                          controller.showHidden = value;
+                          controller.currentDir = controller.currentDir;
+                          Navigator.pop(context);
+                        });
+                      },
+                    ),
+                  ),
+                ],
+              ),
               IconButton(
                 icon: const Icon(
                   Icons.create_new_folder_outlined,
@@ -282,6 +309,7 @@ class WorkspaceController with ChangeNotifier {
   late String _currentDir;
   final List<double> _columnWidths = [480, 180, 120, 120];
   bool _ascending = true;
+  bool _showHidden = false;
   int _columnIndex = 0;
   final List<EntityInfo> _selectedItems = [];
   List<EntityInfo>? _currentInfo;
@@ -301,7 +329,7 @@ class WorkspaceController with ChangeNotifier {
         _loadingProgress = value;
         notifyListeners();
       },
-      showHidden: true,
+      showHidden: _showHidden,
       ascending: _ascending,
       columnIndex: _columnIndex,
       onFileSystemException: (value) {},
@@ -328,6 +356,12 @@ class WorkspaceController with ChangeNotifier {
   bool get ascending => _ascending;
   set ascending(bool value) {
     _ascending = value;
+    notifyListeners();
+  }
+
+  bool get showHidden => _showHidden;
+  set showHidden(bool value) {
+    _showHidden = value;
     notifyListeners();
   }
 


### PR DESCRIPTION
## Description

- Added a "show hidden files" option inside a pop up menu to the side of the Add new folder button.

- This is usually seen in files applications

- No dependency required.

- Fixes #9 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/67337602/159297388-cd721fcd-b256-4d30-a3d5-2a70b89f5ed8.png)
![image](https://user-images.githubusercontent.com/67337602/159297496-0c7c1f01-d03b-4452-a586-bf4326028b93.png)

## Type of change

UI/Backend change

Please tick the relevant option by putting an X inside the bracket

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] All current GitHub actions pass
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
